### PR TITLE
Sync mriduls/esssans with copier template

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: 3b545e9
+_commit: 055c220
 _src_path: gh:scipp/copier_template
 description: SANS data reduction for the European Spallation Source
 max_python: '3.12'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,6 +3,7 @@
 import doctest
 import os
 import sys
+from importlib.metadata import version as get_version
 
 from ess import sans
 
@@ -111,10 +112,8 @@ master_doc = 'index'
 # built documents.
 #
 
-# The short X.Y version.
-version = sans.__version__
-# The full version, including alpha/beta/rc tags.
-release = sans.__version__
+release = get_version("esssans")
+version = ".".join(release.split('.')[:3])  # CalVer
 
 warning_is_error = True
 


### PR DESCRIPTION
This PR updates the project to the latest version of scipp's [copier-template](https://github.com/scipp/copier_template).
Remember to check for any conflicts and resolve them.